### PR TITLE
Updated building plugins with 1.0.0-alpha1 release of OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains all the things you ever wanted to know about OpenSearch
 Until OpenSearch and other artifacts are published to Maven Central [OpenSearch#581](https://github.com/opensearch-project/OpenSearch/issues/581), plugins may require building all their dependencies and publishing them to Maven local.
 
 #### Publish OpenSearch to Maven Local
-Use the `1.0.0-alpha1` tag to have a stable version [1.0.0-alpha1 Tag](https://github.com/opensearch-project/OpenSearch/releases/tag/1.0.0-alpha1) 
+Use the `1.0.0-alpha1` tag to have a stable version [1.0.0-alpha1 Tag](https://github.com/opensearch-project/OpenSearch/releases/tag/1.0.0-alpha1). 
 
 This will publish artifacts which are part of release version `1.0.0-alpha1`.
 This will support running integration tests. Please note that the limitation for integration tests is that it is only supported for builds on linux platform.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Until OpenSearch and other artifacts are published to Maven Central [OpenSearch#
 Use the `1.0.0-alpha1` tag to have a stable version [1.0.0-alpha1 Tag](https://github.com/opensearch-project/OpenSearch/releases/tag/1.0.0-alpha1) 
 
 This will publish artifacts which are part of release version `1.0.0-alpha1`.
+This will support running integration tests. Please note that the limitation for integration tests is that it is only supported for builds on linux platform.
+
 ```
 ~/OpenSearch (main)> git checkout 1.0.0-alpha1 -b alpha1-release
 ~/OpenSearch (main)> ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Your plugin may have more dependencies than just OpenSearch. For example, [anoma
 
 The following trivial build script changes were made to successfully run `./gradlew publishToMavenLocal` in each of these.
 
-* [common-utils#8](https://github.com/opensearch-project/common-utils/pull/8)
-* [job-scheduler#8](https://github.com/opensearch-project/job-scheduler/pull/8)
-* [anomaly-detection#13](https://github.com/opensearch-project/anomaly-detection/pull/13)
+* [common-utils#9](https://github.com/opensearch-project/common-utils/pull/9)
+* [job-scheduler#11](https://github.com/opensearch-project/job-scheduler/pull/11)
+* [anomaly-detection#18](https://github.com/opensearch-project/anomaly-detection/pull/18)
 
 We plan to remove the need for this work-around via [OpenSearch#581](https://github.com/opensearch-project/OpenSearch/issues/581).
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ This repository contains all the things you ever wanted to know about OpenSearch
 Until OpenSearch and other artifacts are published to Maven Central [OpenSearch#581](https://github.com/opensearch-project/OpenSearch/issues/581), plugins may require building all their dependencies and publishing them to Maven local.
 
 #### Publish OpenSearch to Maven Local
+Use the `1.0.0-alpha1` tag to have a stable version [1.0.0-alpha1 Tag](https://github.com/opensearch-project/OpenSearch/releases/tag/1.0.0-alpha1) 
 
+This will publish artifacts which are part of release version `1.0.0-alpha1`.
 ```
-~/OpenSearch (main)> ./gradlew publishToMavenLocal
+~/OpenSearch (main)> git checkout 1.0.0-alpha1 -b alpha1-release
+~/OpenSearch (main)> ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false
 ```
 
-On Unix, the local Maven repository is the `~/.m2` folder. For example, the above command produces `~/.m2/repository/org/opensearch/opensearch/1.0.0-SNAPSHOT/opensearch-1.0.0-SNAPSHOT.jar`.
+On Unix, the local Maven repository is the `~/.m2` folder. For example, the above command produces `~/.m2/repository/org/opensearch/opensearch/1.0.0-alpha1/opensearch-1.0.0-alpha1.jar`.
 
 #### Use OpenSearch from Maven Local in Plugins
 


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Updating Readme to build plugins with stable version of `1.0.0-alpha1`.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
