### PR TITLE
Adding upgrading doc for plugins to move from Elasticsearch to OpenSe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   - [Building with OpenSearch](#building-with-opensearch)
     - [Publish OpenSearch to Maven Local](#publish-opensearch-to-maven-local)
     - [Use OpenSearch from Maven Local in Plugins](#use-opensearch-from-maven-local-in-plugins)
+  - [Upgrading Plugins to work with OpenSearch](#upgrading-plugins-to-work-with-opensearch)
 - [Contrbuting](#contrbuting)
 - [License](#license)
 
@@ -33,7 +34,10 @@ The following trivial build script changes were made to successfully run `./grad
 
 We plan to remove the need for this work-around via [OpenSearch#581](https://github.com/opensearch-project/OpenSearch/issues/581).
 
-## Contrbuting
+## Upgrading Plugins to work with OpenSearch
+To upgrade your existing plugins to work with OpenSearch, see [Upgrading Guide](./UPGRADING.md)
+
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,57 @@
+## Upgrading Plugins to OpenSearch/OpenSearch Dashboards
+
+For the plugins to work with OpenSearch here are all the steps you can take and get them building, passing all the tests.
+
+### Upgrading
+We will upgrade the plugins to use OpenSearch/Dashboards 1.0.0.
+
+#### OpenSearch Plugins
+
+1. Consume artifacts from OpenSearch by publishing them locally. Please see [Readme](./README.md#building-with-opensearch)
+2. Change the namespaces from `org.elasticsearch` to `org.opensearch`. Use the naming convention below.
+3. Consuming dependencies with OpenSearch/Dashboards 1.0.0. 
+   * For dependencies `securemock`, `mocksocket` and `jna-build` please continue to use `org.elasticsearch` namespace.
+4. Build and test your plugin.
+5. Please report all run time failures of OpenSearch to [OpenSearch Issues](http://github.com/opensearch-project/opensearch/issues) and 
+runtime failures of plugins in [OpenSearch plugin Issues](https://github.com/opensearch-project/opensearch-plugins/issues).
+
+Here is an example for the changes which were done for OpenSearch plugin:
+https://github.com/opensearch-project/anomaly-detection/pull/1
+
+##### Naming Convention
+
+Naming convention followed:
+
+* `Elasticsearch` -> `OpenSearch`
+* `elasticsearch` -> `opensearch`
+* `es` -> `opensearch`
+* `Es` -> `OpenSearch`
+* `ES` -> `OpenSearch`
+* `ELASTICSEARCH` -> `OPENSEARCH`
+* Anything with Kibana follow the naming convention below.
+
+#### OpenSearch Dashboard plugins
+
+1. Change the namespaces from `Kibana` to `OpenSearch-Dashboards`. Use the naming convention below.
+2. Download and install OpenSearch-Dashboards. Make sure the version specific in `package.json` matches the OpenSearch version.
+3. Create plugins directory in the root of the project, if plugins directory doesn't exist already.
+4. Run `yarn osd bootstrap` inside `opensearch-dashboards/plugins/opensearch-dashboards-plugin`.
+5. Build and test your plugin.
+6. Please report all run time failures of OpenSearch to [OpenSearch Dashboards Issues](http://github.com/opensearch-project/opensearch-dashboards/issues) and 
+runtime failures of plugins in [OpenSearch plugin Issues](https://github.com/opensearch-project/opensearch-plugins/issues).
+
+
+##### Naming Convention
+
+* `kibana` -> `opensearchDashboards`
+* `Kibana` -> `OpenSearchDashboards`
+* `KIBANA` -> `OPENSEARCH_DASHBOARDS`
+* `kbn` -> `osd`
+* `Kbn` -> `Osd`
+* `KBN` -> `OSD`
+* `kib` -> `osd`
+* `Kib` -> `Osd`
+* `KIB` -> `OSD`
+
+Here is an example for the changes which were done for OpenSearch Dashboard plugin:
+https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,21 +1,21 @@
 ## Upgrading Plugins to OpenSearch/OpenSearch Dashboards
 
-For the plugins to work with OpenSearch here are all the steps you can take and get them building, passing all the tests.
+These are all the steps to upgrade plugins to work with OpenSearch and OpenSearch Dashboards, including building, and passing all tests.
 
 ### Upgrading
 We will upgrade the plugins to use OpenSearch/Dashboards 1.0.0.
 
 #### OpenSearch Plugins
 
-1. Consume artifacts from OpenSearch by publishing them locally. Please see [Readme](./README.md#building-with-opensearch)
+1. Consume artifacts from OpenSearch by publishing them locally. Please see [Readme](./README.md#building-with-opensearch).
 2. Change the namespaces from `org.elasticsearch` to `org.opensearch`. Use the naming convention below.
 3. Consuming dependencies with OpenSearch/Dashboards 1.0.0. 
    * For dependencies `securemock`, `mocksocket` and `jna-build` please continue to use `org.elasticsearch` namespace.
 4. Build and test your plugin.
-5. Please report all run time failures of OpenSearch to [OpenSearch Issues](http://github.com/opensearch-project/opensearch/issues) and 
+5. Report all runtime failures of OpenSearch to [OpenSearch Issues](http://github.com/opensearch-project/opensearch/issues) and 
 runtime failures of plugins in [OpenSearch plugin Issues](https://github.com/opensearch-project/opensearch-plugins/issues).
 
-Here is an example for the changes which were done for OpenSearch plugin:
+Here is an example for the changes which were done for OpenSearch plugin.
 https://github.com/opensearch-project/anomaly-detection/pull/1
 
 ##### Naming Convention
@@ -37,7 +37,7 @@ Naming convention followed:
 3. Create plugins directory in the root of the project, if plugins directory doesn't exist already.
 4. Run `yarn osd bootstrap` inside `opensearch-dashboards/plugins/opensearch-dashboards-plugin`.
 5. Build and test your plugin.
-6. Please report all run time failures of OpenSearch to [OpenSearch Dashboards Issues](http://github.com/opensearch-project/opensearch-dashboards/issues) and 
+6. Report all runtime failures of OpenSearch to [OpenSearch Dashboards Issues](http://github.com/opensearch-project/opensearch-dashboards/issues) and 
 runtime failures of plugins in [OpenSearch plugin Issues](https://github.com/opensearch-project/opensearch-plugins/issues).
 
 
@@ -53,5 +53,5 @@ runtime failures of plugins in [OpenSearch plugin Issues](https://github.com/ope
 * `Kib` -> `Osd`
 * `KIB` -> `OSD`
 
-Here is an example for the changes which were done for OpenSearch Dashboard plugin:
+Here is an example for the changes which were done for OpenSearch Dashboard plugin.
 https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Adding upgrading doc for plugins to move from Elasticsearch to OpenSearch

### Issues Resolved
#2 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
