### PR TITLE
Added naming conventions for plugins.

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,122 @@
+- [Plugin Naming Conventions](#plugin-naming-conventions)
+    - [GitHub](#github)
+        - [OpenSearch Plugins](#opensearch-plugins)
+        - [OpenSearch Dashboard Plugins](#opensearch-dashboard-plugins)
+    - [Metadata](#metadata)
+        - [OpenSearch Plugins](#opensearch-plugins)
+        - [OpenSearch Dashboard Plugins](#opensearch-dashboard-plugins)
+    - [Artifacts](#artifacts)
+        - [OpenSearch Plugins](#opensearch-plugins)
+        - [OpenSearch Dashboards Plugins](#opensearch-dashboards-plugins)
+    - [Folders](#folders)
+        - [OpenSearch Plugins](#opensearch-plugins)
+        - [OpenSearch Dashboard Plugins](#opensearch-dashboard-plugins)
+    - [Classes](#classes)
+    - [Settings](#settings)
+    - [APIs](#apis)
+    - [Indices](#indices)
+    - [Identifiers](#identifiers)
+    - [Variables](#variables)
+
+## Plugin Naming Conventions
+
+These are _recommended_ plugin naming conventions. YMMV.
+
+### GitHub
+
+- Within the [opensearch-project org](https://github.com/opensearch-project), do not include the word `OpenSearch` or `OpenSearch Dashboards` in the repo name.
+- Inherit templates, CoC, etc., from [opensearch-project/.github](https://github.com/opensearch-project/.github).
+- Use lowercase repo names.
+- Provide a meaningful description, e.g. `An OpenSearch Dashboards plugin to perform real-time and historical anomaly detection on OpenSearch data.`
+
+#### OpenSearch Plugins
+
+- Do not include the word `plugin` in the repo name, e.g. [job-scheduler](https://github.com/opensearch-project/job-scheduler).
+
+#### OpenSearch Dashboard Plugins
+
+- Prefix OpenSearch Dashboards plugins with `dashboards-`, e.g. [dashboards-reports](https://github.com/opensearch-project/dashboards-reports).
+
+### Metadata
+
+#### OpenSearch Plugins
+
+- Plugin name starts with `opensearch-`.
+- Include `opensearch-` in the plugin name.
+- Description does not end with a period.
+- Include `OpenSearch` and `plugin` in the descripion. 
+
+```groovy
+opensearchplugin {
+    name 'opensearch-job-scheduler'
+    description 'OpenSearch Job Scheduler plugin'
+    classname 'org.opensearch.jobscheduler.JobSchedulerPlugin'
+}
+```
+
+#### OpenSearch Dashboard Plugins
+
+- Plugin ID is lowercase camelcase, e.g. `notebooksDashboards`.
+- Version follows [semver](https://semver.org/).
+
+For example, [dashboards-notebooks/opensearch_dashboards.json](https://github.com/opensearch-project/dashboards-notebooks/blob/main/dashboards-notebooks/opensearch_dashboards.json).
+
+```json
+{
+  "id": "notebooksDashboards",
+  "version": "1.0.0.0-beta1",
+  "opensearchDashboardsVersion": "1.0.0-beta1",
+  "server": true,
+  "ui": true,
+  "requiredPlugins": ["navigation", "embeddable", "dashboard"],
+  "optionalPlugins": []
+}
+```
+
+### Artifacts
+
+#### OpenSearch Plugins
+
+- Artifacts are of the `<package name>-<version>` format, e.g. `opensearch-job-scheduler-1.0.0.0-beta1.zip`.
+
+#### OpenSearch Dashboards Plugins
+
+- Artifacts are of the `<package name>-<version>` format, e.g. `dashboards-notebooks-1.0.0.0-beta1.zip`.
+
+### Folders
+
+#### OpenSearch Plugins
+
+- Always use snake-case.
+- Include full plugin name, e.g. `plugins/opensearch-knn`.
+
+#### OpenSearch Dashboard Plugins
+
+- Always use snake-case.
+- Include full plugin name, e.g. `plugins/dashboards-notebooks`. Currently broken, see [OpenSearch-Dashboards#322](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/322).
+
+### Classes
+
+- Lowercase namespaces, e.g. `org.opensearch.jobscheduler`.
+- CamelCase classes, e.g. `org.opensearch.jobscheduler.JobSchedulerPlugin`.
+
+### Settings
+
+- Settings do not have a prefix.
+- Avoid using `opensearch` in the setting name, e.g. `jobscheduler.request_timeout` and not `opensearch.jobscheduler.request_timeout`.
+
+### APIs
+
+- Use `_` as prefix for APIs, e.g. `_plugins/_anomaly_detection/*`.
+
+### Indices
+
+- Use `.` as prefix for indices.
+
+### Identifiers
+
+- TODO
+
+### Variables
+
+- Use common sense for your plugin.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 - [OpenSearch Plugins](#opensearch-plugins)
+    - [Naming Conventions](#naming-conventions)
     - [Building Plugins with OpenSearch](#building-plugins-with-opensearch)
     - [Upgrading Plugins to work with OpenSearch](#upgrading-plugins-to-work-with-opensearch)
     - [Installing Plugins](#installing-plugins)
@@ -9,6 +10,10 @@
 ## OpenSearch Plugins
 
 This repository contains all the things you ever wanted to know about OpenSearch plugins.
+
+### Naming Conventions
+
+See [CONVENTIONS](CONVENTIONS.md).
 
 ### Building Plugins with OpenSearch
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

A starter for plugin naming conventions.
 
### Issues Resolved

#10 
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
