### PR TITLE
Suggested temporary workaround for running integTests on non Linux platforms

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,7 +11,7 @@ Use the `1.0.0-beta1` tag to have a stable version [1.0.0-beta1 Tag](https://git
 
 This will publish artifacts which are part of release version `1.0.0-beta1`.
 This will support running integration tests. Please note that the limitation for integration tests is that it is only supported for builds on linux platform.
-(A _temporary_ workaround for this limitation is to update the `testClusters.integTest.testDistribution` param value in the plugins' `build.gradle` to be equal to `INTEG_TEST` rather than `ARCHIVE`). 
+In order to run the integration tests on non-linux platforms, temporarily change the `testClusters.integTest.testDistribution` param in the `build.gradle` file of the plugin from `"ARCHIVE"` to `"INTEG_TEST"` ([see related issue](https://github.com/opensearch-project/opensearch-plugins/issues/40)).
 
 ```
 ~/OpenSearch (main)> git checkout 1.0.0-beta1 -b beta1-release

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,6 +11,7 @@ Use the `1.0.0-beta1` tag to have a stable version [1.0.0-beta1 Tag](https://git
 
 This will publish artifacts which are part of release version `1.0.0-beta1`.
 This will support running integration tests. Please note that the limitation for integration tests is that it is only supported for builds on linux platform.
+(A _temporary_ workaround for this limitation is to update the `testClusters.integTest.testDistribution` param value in the plugins' `build.gradle` to be equal to `INTEG_TEST` rather than `ARCHIVE`). 
 
 ```
 ~/OpenSearch (main)> git checkout 1.0.0-beta1 -b beta1-release


### PR DESCRIPTION
### Description
Suggesting a workaround for users to be able to test their plugins until the core issue is resolved.
 
### Issues Resolved
This suggestion is related to https://github.com/opensearch-project/OpenSearch/issues/600
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
