### PR TITLE
Make all identifiers LEGACY_OPENDISTRO_.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -156,8 +156,8 @@ From here on the doc will be focussed on an ODFE plugin as an example.
 3. All new APIs will be implemented with `_plugins` as defined in the [Naming Conventions](./CONVENTIONS.md).
 4. The method `replacedRoutes()` is overriden and this should now have both `_opendistro` and `_plugins` APIs.
     ```java
-    public static final String LEGACY_AD_BASE = "/_opendistro/_anomaly_detection";
-    public static final String LEGACY_OPENDISTRO_AD_BASE_URI = LEGACY_AD_BASE + "/detectors";
+    public static final String LEGACY_OPENDISTRO_AD_BASE = "/_opendistro/_anomaly_detection";
+    public static final String LEGACY_OPENDISTRO_AD_BASE_URI = LEGACY_OPENDISTRO_AD_BASE + "/detectors";
     public static final String AD_BASE_URI = "/_plugins/_anomaly_detection";
     public static final String AD_BASE_DETECTORS_URI = AD_BASE_URI + "/detectors";
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I am seeing a lot of changes that don't include `OPENDISTRO` (e.g. https://github.com/opensearch-project/alerting/pull/16/files) and was wondering where it came from. I think it's here.
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
