### PR TITLE
Build multiple plugin artifacts.

### DIFF
--- a/META.md
+++ b/META.md
@@ -8,6 +8,7 @@
     - [Add a New Plugin](#add-a-new-plugin)
     - [Create or Update Labels in All Plugin Repos](#create-or-update-labels-in-all-plugin-repos)
     - [Create an Issue in All Plugin Repos](#create-an-issue-in-all-plugin-repos)
+    - [Build Multiple Plugin Artifacts](#build-multiple-plugin-artifacts)
 
 <!-- /TOC -->
 
@@ -61,4 +62,47 @@ Create a file for the issue body, e.g. `issue.md`.
 
 ```
 meta exec "gh issue create --label backwards-compatibility --title 'Ensure backwards compatibility with ODFE' --body-file ../issue.md"
+```
+
+### Build Multiple Plugin Artifacts
+
+You might want to do some bookkeeping, first.
+
+```
+rm -rf ~/.m2
+```
+
+All the work will be done inside `plugins`, which includes the [meta](plugins/.meta) project that lists all the plugins.
+
+```
+> cd plugins
+plugins>
+```
+
+First, build OpenSearch, e.g. 1.x.
+
+```
+plugins> git clone git@github.com:opensearch-project/OpenSearch.git
+plugins> cd OpenSearch
+plugins/OpenSearch (main)> git checkout 1.x
+plugins/OpenSearch (1.x)> ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
+plugins/OpenSearch (1.x)> cd ..
+```
+
+Update code in all plugins.
+
+```
+meta git update
+meta git pull
+```
+
+Build all Gradle plugins into maven local (to make dependencies available), then assemble artifacts and copy them into one place.
+
+```
+meta exec "test -e ./gradlew && ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1 -Dbuild.snapshot=false || echo Skipping ..."
+
+meta exec "test -e ./gradlew && ./gradlew assemble -Dopensearch.version=1.0.0-rc1 -Dbuild.snapshot=false || echo Skipping ..."
+
+mkdir dist
+meta exec "test -e ./gradlew && cp build/distributions/*.zip ../dist || echo Skipping ..."
 ```

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,3 +1,4 @@
+/common-utils/
 /alerting/
 /anomaly-detection/
 /asynchronous-search/

--- a/plugins/.meta
+++ b/plugins/.meta
@@ -1,5 +1,7 @@
 {
   "projects": {
+    "common-utils": "git@github.com:opensearch-project/common-utils.git",
+    "job-scheduler": "git@github.com:opensearch-project/job-scheduler.git",
     "alerting": "git@github.com:opensearch-project/alerting.git",
     "anomaly-detection": "git@github.com:opensearch-project/anomaly-detection.git",
     "asynchronous-search": "git@github.com:opensearch-project/asynchronous-search.git",
@@ -7,7 +9,6 @@
     "dashboards-reports": "git@github.com:opensearch-project/dashboards-reports.git",
     "dashboards-visualizations": "git@github.com:opensearch-project/dashboards-visualizations.git",
     "index-management": "git@github.com:opensearch-project/index-management.git",
-    "job-scheduler": "git@github.com:opensearch-project/job-scheduler.git",
     "k-nn": "git@github.com:opensearch-project/k-nn.git",
     "performance-analyzer": "git@github.com:opensearch-project/performance-analyzer.git",
     "security-dashboards-plugin": "git@github.com:opensearch-project/security-dashboards-plugin.git",


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

This iterates over plugins and builds the ones that use gradle. With no changes in generates these successfully.

```
opensearch-asynchronous-search-1.0.0.0-rc1.zip
opensearch-index-management-1.0.0.0-rc1.zip
opensearch-job-scheduler-1.0.0.0-rc1.zip
opensearch-knn-1.0.0.0-rc1.zip
```

If this is helpful and saves the infra team time, I can track down changes in others, e.g. security tries to copy some things around its scripts. Or I can try and figure out how to execute GitHub workflows.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
