### PR TITLE
Adding broken links check using github actions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,23 @@
+name: Link Checker
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  linkchecker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: lychee Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@master
+        with:
+          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Fail if there were link errors
+        run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 - [OpenSearch Plugins](#opensearch-plugins)
-    - [Naming Conventions](#naming-conventions)
-    - [Managing OpenSearch Plugins](#managing-opensearch-plugins)
-    - [Building Plugins with OpenSearch](#building-plugins-with-opensearch)
-    - [Upgrading Plugins to work with OpenSearch](#upgrading-plugins-to-work-with-opensearch)
-    - [Installing Plugins](#installing-plugins)
-    - [Plugin Release Notes](#plugin-release-notes)
-    - [Headers](#headers)
+  - [Naming Conventions](#naming-conventions)
+  - [Managing OpenSearch Plugins](#managing-opensearch-plugins)
+  - [Building Plugins with OpenSearch](#building-plugins-with-opensearch)
+  - [Upgrading Plugins to work with OpenSearch](#upgrading-plugins-to-work-with-opensearch)
+  - [Installing Plugins](#installing-plugins)
+  - [Plugin Release Notes](#plugin-release-notes)
+  - [Headers](#headers)
+  - [Standards](#standards)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -41,6 +42,10 @@ Plugins generally use a standard format for release notes, see [RELEASE_NOTES](.
 ### Headers
 
 See [HEADERS](HEADERS.md) for details of headers including licenses.
+
+### Standards
+
+See [STANDARDS](STANDARDS.md) for information regarding plugin standards.
 
 ## Contributing
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,0 +1,22 @@
+# Plugin Standards
+
+This document lists down the standards for OpenSearch plugins which can be used by plugin authors.
+
+- [Plugin Standards](#plugin-standards)
+  - [Broken Links Checker](#broken-links-checker)
+  - [Plugin Release Notes](#plugin-release-notes)
+  - [License Headers](#license-headers)
+
+## Broken Links Checker
+
+Create a Github Actions workflow to check for broken links in text files (.md, .html, .txt, .json) on pull requests and push. See [.github/workflows/links.yml](.github/workflows/links.yml) for an example.
+
+See [lycheeverse/lychee-action](https://github.com/lycheeverse/lychee-action) for more information.
+
+## Plugin Release Notes
+
+Release notes for plugins are located at [RELEASE_NOTES.md](RELEASE_NOTES.md).
+
+## License Headers
+
+License Header details are located at [HEADERS.md](HEADERS.md).


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
This PR adds a github action for checking broken links in the markdown files. This check is triggered on PRs and push.
 
###Testing
I tested this action on a dummy repo https://github.com/VachaShah/TestGithubActions/actions by adding a broken link in some text files, the action failed with the broken link. Also, I have verified by creating a PR with some broken links in files.

### Issues Resolved
#29 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
