### PR TITLE
Added usage examples to enable automated license headers' checks

### DIFF
--- a/HEADERS.md
+++ b/HEADERS.md
@@ -25,3 +25,15 @@ All files in opensearch-project should use OpenSearch SPDX license.
 If files have any existing headers keep them and add OpenSearch SPDX license header on top.  
 _Example_: [Version.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/Version.java) file has license header from Elasticsearch.
  The existing license is not removed and OpenSearch SPDX license header is added on top of it.   
+
+### Automated License Headers' Checks
+
+OpenSearch plugins have an inbuilt `:licenseHeaders` Gradle task to perform automated license headers' checks. All plugins should keep this check enabled in their `build.gradle` file.
+
+Plugins can also use [IntelliJ's Copyright](https://www.jetbrains.com/help/idea/copyright.html) feature to generate the license headers. The copyright profile can be shared in the plugin's repository so that license headers are consistently generated for all contributors.
+
+Example: [Enable license headers check + Add IntelliJ copyright profile](https://github.com/opensearch-project/k-NN/pull/41)
+
+For complex multi-module projects and libraries, the `:licenseHeaders` check may not be available outside the plugin module. Such projects should consider using plugins like [Spotless](https://github.com/diffplug/spotless) to validate and/or generate the license headers.
+
+Example: [Spotless configuration to generate the license headers](https://github.com/opensearch-project/performance-analyzer/blob/1357d86e3936c1de8de951e85f2db792e49d8a02/build.gradle#L89-L104)


### PR DESCRIPTION
### Description
Added usage examples to enable automated license headers' checks.
 
### Issues Resolved
Related to https://github.com/opensearch-project/opensearch-plugins/issues/49 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma <ketan9495@gmail.com>