### PR TITLE
Adding documentation for implementing bwc tests in plugins

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -15,7 +15,7 @@ This document lists down the standards for OpenSearch plugins which can be used 
   - [Code Coverage Report](#code-coverage-report)
   - [License Headers](#license-headers)
   - [Public Documentation](#public-documentation)
-  - [Release Notes](#release-notes)  
+  - [Release Notes](#release-notes)
 
 ## Development Best Practices
 
@@ -53,7 +53,7 @@ See [lycheeverse/lychee-action](https://github.com/lycheeverse/lychee-action) fo
 
 ## CI Workflows
 
-CI Workflows should be setup to run and verify plugin unit and integration tests.  
+CI Workflows should be setup to run and verify plugin unit, integration and backwards compatibility tests.
 Workflows should run on main and release branches including pull requests merging into them.
 
 _Example_: See CI Workflow in [anomaly-detection](https://github.com/opensearch-project/anomaly-detection/blob/main/.github/workflows/CI.yml). 


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
Adding documentation for backwards compatibility tests for plugins.
 
### Issues Resolved
[opensearch-build#223](https://github.com/opensearch-project/opensearch-build/issues/223)
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
