### PR TITLE
Added a repeatable process to create an issue for a release in every plugin repo.

### DIFF
--- a/META.md
+++ b/META.md
@@ -69,6 +69,12 @@ Create a file for the issue body, e.g. `issue.md`.
 meta exec "gh issue create --label backwards-compatibility --title 'Ensure backwards compatibility with ODFE' --body-file ../issue.md"
 ```
 
+One of the common scenarios for creating issues in all plugin repos is creating a release issue that links back to a parent release issue in opensearch-build. 
+
+1. Locate the parent issue, e.g. [opensearch-build#567](https://github.com/opensearch-project/opensearch-build/issues/567) for version 1.2.
+2. Clone the last template in [templates/releases/](templates/releases), and update version numbers and links, e.g. [release-1.2.0.md](templates/releases/release-1.2.0.md).
+3. Run `meta exec "gh issue create --label release --title 'Release version 1.2' --body-file ../templates/releases/release-1.2.0.md"`.
+
 ### Open a Pull Request in Each Repo
 
 In [opensearch-build#497](https://github.com/opensearch-project/opensearch-build/issues/497) we needed to remove `integtest.sh` from each repo.

--- a/templates/releases/release-1.2.0.md
+++ b/templates/releases/release-1.2.0.md
@@ -1,0 +1,32 @@
+Coming from [opensearch-build#567](https://github.com/opensearch-project/opensearch-build/issues/567), release version 1.2. Please follow the following checklist.
+
+### Preparation
+
+- [ ] Assign this issue to a release owner.
+- [ ] Finalize scope and feature set and update [the Public Roadmap](https://github.com/orgs/opensearch-project/projects/1).
+- [ ] Create, update, triage and label all features and issues targeted for this release with `v1.2.0`.
+
+### CI/CD
+
+- [ ] Increment version on main to `1.2.0.0`.
+- [ ] Ensure working and passing CI.
+- [ ] Re(add) this repo to the [manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/1.2.0).
+
+### Pre-Release
+
+- [ ] Branch and build from a `1.2` branch.
+- [ ] Update your branch in the [manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/1.2.0).
+- [ ] Feature complete, pencils down.
+- [ ] Fix bugs that target this release.
+
+### Release
+
+- [ ] Complete [documentation](https://github.com/opensearch-project/documentation-website).
+- [ ] Gather, review and publish release notes.
+- [ ] Verify all issued labeled for this release are closed or labelled for the next release.
+
+### Post Release
+
+- [ ] Create [a release tag](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging).
+- [ ] Suggest improvements to [this template](https://github.com/opensearch-project/opensearch-plugins/templates/release.md).
+- [ ] Conduct a postmortem, and publish its results.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

A meta for creating an issue in every repo to release a version.

I think we should start with 1.2, but I am open for also doing it for 1.1.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
