### PR TITLE
Fix path for template and add label.

### DIFF
--- a/META.md
+++ b/META.md
@@ -73,7 +73,7 @@ One of the common scenarios for creating issues in all plugin repos is creating 
 
 1. Locate the parent issue, e.g. [opensearch-build#567](https://github.com/opensearch-project/opensearch-build/issues/567) for version 1.2.
 2. Clone the last template in [templates/releases/](templates/releases), and update version numbers and links, e.g. [release-1.2.0.md](templates/releases/release-1.2.0.md).
-3. Run `meta exec "gh issue create --label release --title 'Release version 1.2' --body-file ../templates/releases/release-1.2.0.md"`.
+3. From [plugins](plugins), run `meta exec "gh issue create --label v1.2.0 --title 'Release version 1.2' --body-file ../../templates/releases/release-1.2.0.md"`.
 
 ### Open a Pull Request in Each Repo
 

--- a/templates/releases/release-1.2.0.md
+++ b/templates/releases/release-1.2.0.md
@@ -28,5 +28,5 @@ Coming from [opensearch-build#567](https://github.com/opensearch-project/opensea
 ### Post Release
 
 - [ ] Create [a release tag](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging).
-- [ ] Suggest improvements to [this template](https://github.com/opensearch-project/opensearch-plugins/templates/release.md).
+- [ ] [Suggest improvements](https://github.com/opensearch-project/opensearch-plugins/issues/new) to [this template](https://github.com/opensearch-project/opensearch-plugins/templates/releases/release-1.2.0.md).
 - [ ] Conduct a postmortem, and publish its results.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I went ahead and created 1.2 issues as children of https://github.com/opensearch-project/opensearch-build/issues/567, which required some path fixing.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
