### PR TITLE
Updates build doc to use public Maven repo

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,9 +1,3 @@
-# Building and Developing Plugins with OpenSearch
-
-## Building Plugins with OpenSearch
-
-Until OpenSearch and other artifacts are published to Maven Central [OpenSearch#581](https://github.com/opensearch-project/OpenSearch/issues/581), plugins may require building all their dependencies and publishing them to Maven local.
-
 - [Building and Developing Plugins with OpenSearch](#building-and-developing-plugins-with-opensearch)
   - [Building Plugins with OpenSearch](#building-plugins-with-opensearch)
     - [Publish OpenSearch to Maven Local](#publish-opensearch-to-maven-local)
@@ -15,6 +9,58 @@ Until OpenSearch and other artifacts are published to Maven Central [OpenSearch#
       - [Mandatory elements](#mandatory-elements)
       - [Optional elements](#optional-elements)
     - [Notes](#notes)
+
+
+# Building and Developing Plugins with OpenSearch
+
+## Building Plugins with OpenSearch
+
+OpenSearch and other artifacts are available at public [Maven repository](https://aws.oss.sonatype.org/content/repositories/) for plugins to build against. All `main` and `<major-version>.x (ex: 1.x)` branches for plugins should consume `-SNAPSHOT` artifacts, so that they are built against the latest OpenSearch and other dependencies.
+
+Plugins must declare the dependencies for the root projects and subprojects in the following order. The first two repositories `mavenLocal()` and `maven(aws.oss.sonatype.org)` are mandatory, while the rest are optional and depends on what other dependencies plugins needs to build.
+
+```
+# <plugin-root>/build.gradle
+
+    repositories {
+        mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+        jcenter()
+        <any other repository>
+    }
+
+```
+
+This also applies for dependencies for build script itself, in-case the `buildscript{}` needs to consume OpenSearch `build-tools` artifact.
+
+```
+# <plugin-root>/build.gradle
+
+buildscript {
+    ...
+    ...
+    
+    repositories {
+        mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+        jcenter()
+    }
+    dependencies {
+       classpath "org.opensearch.gradle:build-tools:${some_version}"
+       ...
+    }
+}
+```
+
+The default build is a `SNAPSHOT` build and can be skipped (for ex: in case of release) like this:
+
+```bash
+./gradlew build -Dbuild.snapshot=false
+```
 
 ### Publish OpenSearch to Maven Local
 


### PR DESCRIPTION
Signed-off-by: Abbas Hussain <abbas_10690@yahoo.com>

### Description
Updates `BUILDING.md` for OpenSearch plugins to use dependencies from public Maven repo and how the repositories should be ordered for reliable build
 
### Issues Resolved
#45 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
