### PR TITLE
Updated building plugins with the state of 1.1.0 for dependencies.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,140 +1,20 @@
-- [Building and Developing Plugins with OpenSearch](#building-and-developing-plugins-with-opensearch)
-  - [Building Plugins with OpenSearch](#building-plugins-with-opensearch)
-    - [Publish OpenSearch to Maven Local](#publish-opensearch-to-maven-local)
-    - [Use OpenSearch from Maven Local in Plugins](#use-opensearch-from-maven-local-in-plugins)
-  - [Developing new Plugins for OpenSearch](#developing-new-plugins-for-opensearch)
-    - [`plugin-descriptor.properties`](#plugin-descriptorproperties)
-    - [`build.gradle`](#buildgradle)
-    - [Elements for Plugins](#elements-for-plugins)
-      - [Mandatory elements](#mandatory-elements)
-      - [Optional elements](#optional-elements)
-    - [Notes](#notes)
+- [Developing Plugins for OpenSearch](#developing-plugins-for-opensearch)
+  - [`plugin-descriptor.properties`](#plugin-descriptorproperties)
+- [Building within the OpenSearch Build System](#building-within-the-opensearch-build-system)
+  - [Define a Version Based on the OpenSearch Dependency](#define-a-version-based-on-the-opensearch-dependency)
+  - [Consume Dynamic Versions of OpenSearch Dependencies](#consume-dynamic-versions-of-opensearch-dependencies)
+  - [Always Build SNAPSHOT Artifacts](#always-build-snapshot-artifacts)
+  - [Consume Maven Artifacts in Order](#consume-maven-artifacts-in-order)
 
+## Developing Plugins for OpenSearch
 
-# Building and Developing Plugins with OpenSearch
-
-## Building Plugins with OpenSearch
-
-OpenSearch and other artifacts are available at public [Maven repository](https://aws.oss.sonatype.org/content/repositories/) for plugins to build against. All `main` and `<major-version>.x (ex: 1.x)` branches for plugins should consume `-SNAPSHOT` artifacts, so that they are built against the latest OpenSearch and other dependencies.
-
-Plugins must declare the dependencies for the root projects and subprojects in the following order. The first two repositories `mavenLocal()` and `maven(aws.oss.sonatype.org)` are mandatory, while the rest are optional and depends on what other dependencies plugins needs to build.
-
-```
-# <plugin-root>/build.gradle
-
-    repositories {
-        mavenLocal()
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
-        mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-        jcenter()
-        <any other repository>
-    }
-
-```
-
-This also applies for dependencies for build script itself, in-case the `buildscript{}` needs to consume OpenSearch `build-tools` artifact.
-
-```
-# <plugin-root>/build.gradle
-
-buildscript {
-    ...
-    ...
-    
-    repositories {
-        mavenLocal()
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
-        mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-        jcenter()
-    }
-    dependencies {
-       classpath "org.opensearch.gradle:build-tools:${some_version}"
-       ...
-    }
-}
-```
-
-The default build is a `SNAPSHOT` build and can be skipped (for ex: in case of release) like this:
-
-```bash
-./gradlew build -Dbuild.snapshot=false
-```
-
-### Publish OpenSearch to Maven Local
-
-Use the `1.0.0-beta1` tag to have a stable version [1.0.0-beta1 Tag](https://github.com/opensearch-project/OpenSearch/releases/tag/1.0.0-beta1).
-
-This will publish artifacts which are part of release version `1.0.0-beta1`.
-This will support running integration tests. Please note that the limitation for integration tests is that it is only supported for builds on linux platform.
-In order to run the integration tests on non-linux platforms, temporarily change the `testClusters.integTest.testDistribution` param in the `build.gradle` file of the plugin from `"ARCHIVE"` to `"INTEG_TEST"` ([see related issue](https://github.com/opensearch-project/opensearch-plugins/issues/40)).
-
-```
-~/OpenSearch (main)> git checkout 1.0.0-beta1 -b beta1-release
-~/OpenSearch (main)> ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
-```
-
-On Unix, the local Maven repository is the `~/.m2` folder. For example, the above command produces `~/.m2/repository/org/opensearch/opensearch/1.0.0-beta1/opensearch-1.0.0-beta1.jar`.
-
-### Use OpenSearch from Maven Local in Plugins
-
-Your plugin may have more dependencies than just OpenSearch. For example, [anomaly-detection](https://github.com/opensearch-project/anomaly-detection) requires [OpenSearch](https://github.com/opensearch-project/OpenSearch), [common-utils](https://github.com/opensearch-project/common-utils) and [job-scheduler](https://github.com/opensearch-project/job-scheduler) to be successfully published to Maven local, manually. 
-
-The following trivial build script changes were made to successfully run `./gradlew publishToMavenLocal` in each of these.
-
-* [common-utils#9](https://github.com/opensearch-project/common-utils/pull/9)
-* [job-scheduler#11](https://github.com/opensearch-project/job-scheduler/pull/11)
-* [anomaly-detection#18](https://github.com/opensearch-project/anomaly-detection/pull/18)
-
-We plan to remove the need for this work-around via [OpenSearch#581](https://github.com/opensearch-project/OpenSearch/issues/581).
-
-## Developing new Plugins for OpenSearch
-
-All OpenSearch plugins must contain the `plugin-descriptor.properties` file. The fields contained in the `plugin-descriptor.properties` file are mentioned [here](https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/resources/plugin-descriptor.properties). If using the gradle build system, these fields can be specified in the `build.gradle` file and the build system will create the properties file for us.
+The easiest way to get started authoring a new OpenSearch plugin is to follow instruction in [opensearch-project/opensearch-plugin-template-java](https://github.com/opensearch-project/opensearch-plugin-template-java). See also [My First Steps in OpenSearch Plugins](https://logz.io/blog/opensearch-plugins/).
 
 ### `plugin-descriptor.properties`
 
-The properties in the `plugin-descriptor.properties` file are specified as below:
+All OpenSearch plugins require a `plugin-descriptor.properties` file. The fields contained in the `plugin-descriptor.properties` file are documented [here](https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/resources/plugin-descriptor.properties). When using the gradle build system, these fields can be specified in the `build.gradle` file and the build system will generate the properties file.
 
-```
-### mandatory elements for all plugins:
-#
-# 'description': simple summary of the plugin
-description=${description}
-#
-# 'version': plugin's version
-version=${version}
-#
-# 'name': the plugin name
-name=${name}
-#
-# 'classname': the name of the class to load, fully-qualified.
-classname=${classname}
-#
-# 'java.version': version of java the code is built against
-# use the system property java.specification.version
-# version string must be a sequence of nonnegative decimal integers
-# separated by "."'s and may have leading zeros
-java.version=${javaVersion}
-#
-# 'opensearch.version': version of opensearch compiled against
-opensearch.version=${opensearchVersion}
-### optional elements for plugins:
-#
-# 'custom.foldername': the custom name of the folder in which the plugin is installed.
-custom.foldername=${customFolderName}
-#
-#  'extended.plugins': other plugins this plugin extends through SPI
-extended.plugins=${extendedPlugins}
-#
-# 'has.native.controller': whether or not the plugin has a native controller
-has.native.controller=${hasNativeController}
-```
-
-### `build.gradle`
-
-If adding the properties in `build.gradle` file, the gradle plugin will build the `plugin-descriptor.properties` file. Below is an example for the `opensearchplugin` in the `build.gradle`:
+Use `opensearchplugin` in `build.gradle` to generate a `plugin-descriptor.properties`. 
 
 ```
 opensearchplugin {
@@ -144,27 +24,122 @@ opensearchplugin {
 }
 ```
 
-### Elements for Plugins
+## Building within the OpenSearch Build System
 
-#### Mandatory elements
+OpenSearch builds and releases the core engine at the same time as plugins as one monolithic distribution. This is documented in [the build workflow](https://github.com/opensearch-project/opensearch-build). To accommodate this system plugins are required to make build scripts configurable as follows.
 
-| Element | Description |
-| --- | --- |
-| description | simple summary of the plugin |
-| version | version of the plugin |
-| name | name of the plugin. See [CONVENTIONS](./CONVENTIONS.md#plugin-naming-conventions) for more information. |
-| classname | name of the class to load, fully-qualified |
-| java.version | version of java the code is built against. use the system property java.specification.version. version string must be a sequence of nonnegative decimal integers separated by "."'s and may have leading zeros |
-| opensearch.version | version of OpenSearch the plugin is compiled against |
+1. Define the plugin version based on the version of OpenSearch.
+2. Consume dynamic versions of OpenSearch dependencies with `-Dopensearch.version=`.
+3. Support building `-SNAPSHOT` vs. release artifacts with `-Dbuild.snapshot=`, default to always building snapshot.
+4. Prioritize Maven local for dependencies, including OpenSearch.
 
-#### Optional elements
+### Define a Version Based on the OpenSearch Dependency
 
-| Element | Description |
-| --- | --- |
-| custom.foldername | custom folder name for the plugin. This property is available for OpenSearch versions after 1.0.0. If this property is specified, the plugin gets installed in a folder specified in this property. See [opensearch#848](https://github.com/opensearch-project/OpenSearch/pull/848) for more information. |
-| extended.plugins | list of plugins this plugin extends |
-| has.native.controller | whether or not the plugin has a native controller |
+Do not include `version=` in `build.properties`. Instead, dynamically define it in `build.gradle`. Adjust the version when building a snapshot.
 
-### Notes
+```gradle
+buildscript {
+    ext {
+        opensearch_group = "org.opensearch"
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+    }
+}
 
-Refer to the blog post: [My First Steps in OpenSearch Plugins](https://logz.io/blog/opensearch-plugins/) for steps on creating an OpenSearch Plugin.
+allprojects {
+    group = 'org.opensearch'
+
+    version = opensearch_version - "-SNAPSHOT" + ".0"
+}
+```
+
+### Consume Dynamic Versions of OpenSearch Dependencies
+
+OpenSearch uses a 3-digit versioning scheme while plugins have a 4th free digit for patches. Patch the version number to consume dependencies such as common-utils or job-scheduler.
+
+```gradle
+buildscript {
+    ext {
+        // 1.1.0 -> 1.1.0.0, and 1.1.0-SNAPSHOT -> 1.1.0.0-SNAPSHOT
+        opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
+        common_utils_version = System.getProperty("common_utils.version", opensearch_build)
+        job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
+    }
+}
+```
+
+Use the above versions as follows.
+
+```gradle
+dependencies {
+    compile "org.opensearch:opensearch:${opensearch_version}"
+    compile "org.opensearch:common-utils:${common_utils_version}"
+    compileOnly "org.opensearch:opensearch-job-scheduler-spi:${job_scheduler_version}"
+}
+```
+
+### Always Build SNAPSHOT Artifacts
+
+OpenSearch SNAPSHOT artifacts are [built continuously](https://github.com/opensearch-project/opensearch-build) and made available in [AWS OSS Sonatype Maven](https://aws.oss.sonatype.org/content/repositories/). 
+
+Plugins that depend on OpenSearch artifacts should always consume `-SNAPSHOT` artifacts in all branches in their GHA workflows. While it's typical for Java projects to consume snapshot dependencies early and stabilize on released artifacts, OpenSearch builds and releases the core engine at the same time as plugins as one monolithic distribution, thus switching from `-SNAPSHOT` to released artifacts is not necessary. This substitution is performed by [the build workflow](https://github.com/opensearch-project/opensearch-build) by passing `-Dbuild.snapshot=false` into Gradle build.
+
+```gradle
+buildscript {
+    ext {
+        opensearch_group = "org.opensearch"
+        // always default to -SNAPSHOT
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+    }
+}
+
+ext {
+    // support -Dbuild.snapshot=false, but default to true
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+}
+
+allprojects {
+    group = 'org.opensearch'
+
+    version = opensearch_version - "-SNAPSHOT" + ".0"
+
+    // append -SNAPSHOT when building snapshot, which is the default 
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
+}
+```
+
+Note that signed OpenSearch release artifacts are also available in [Maven Central](https://repo1.maven.org/maven2/org/opensearch/) for components that don't release with the monolithic distribution.
+
+### Consume Maven Artifacts in Order 
+
+Plugins must declare the dependencies for the root projects and all sub-projects in the following order. The first two repositories `mavenLocal()` and `maven(aws.oss.sonatype.org)` are required, while the rest are optional as needed for external dependencies.
+
+```gradle
+repositories {
+    mavenLocal()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+    mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
+    jcenter()
+    ...
+}
+```
+
+Same applies for dependencies for the build script itself, in-case the `buildscript { }` needs to consume the OpenSearch `build-tools` artifact.
+
+```gradle
+buildscript {
+    repositories {
+        mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+        jcenter()
+    }
+    dependencies {
+       classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
+       ...
+    }
+}
+```


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Got rid of duplicate documentation that exists in the properties source, removed obsolete sections on maven local and documented the build system as it is now.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
