### PR TITLE
Update instructions for including checksums with maven publications.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -148,17 +148,19 @@ buildscript {
 
 ### Include Checksums in Maven Publications
 
-If your component publishes maven artifacts, use [shadow](https://github.com/johnrengelman/shadow) and always publish checksums.
+If your component publishes maven artifacts, use [shadow](https://github.com/johnrengelman/shadow) and publish to a local repository at a non default location.
+The maven publish plugin used by gradle will not include checksums when publishing to maven local `~/m2/repository`.
 
-```gradle
-tasks.withType(Jar) { task ->
-    task.doLast {
-        ant.checksum algorithm: 'md5', file: it.archivePath
-        ant.checksum algorithm: 'sha1', file: it.archivePath
-        ant.checksum algorithm: 'sha-256', file: it.archivePath, fileext: '.sha256'
-        ant.checksum algorithm: 'sha-512', file: it.archivePath, fileext: '.sha512'
-    }
-}
 ```
-
-Use `./gradlew publishShadowPublicationToMavenLocal` to produce maven artifacts. When building as part of the monolithic distribution customize `scripts/build.sh` to collect maven artifacts. See [job-scheduler#71](https://github.com/opensearch-project/job-scheduler/pull/71/files) for an example.
+publishing {
+    repositories {
+        maven {
+            name = 'staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
+        }
+    }
+    publications {
+        shadow(MavenPublication) { publication ->
+        ...
+```
+Use `./gradlew publishShadowPublicationToStagingRepository` to produce maven artifacts. When building as part of the monolithic distribution customize `scripts/build.sh` to collect maven artifacts. See [job-scheduler#71](https://github.com/opensearch-project/job-scheduler/pull/82/files) for an example.


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Documentation update for publishing checksums with maven.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/699
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
