### PR TITLE
Removing dashboards-visualizations from opensearch plugins

### DIFF
--- a/plugins/.meta
+++ b/plugins/.meta
@@ -5,7 +5,6 @@
     "asynchronous-search": "git@github.com:opensearch-project/asynchronous-search.git",
     "dashboards-notebooks": "git@github.com:opensearch-project/dashboards-notebooks",
     "dashboards-reports": "git@github.com:opensearch-project/dashboards-reports.git",
-    "dashboards-visualizations": "git@github.com:opensearch-project/dashboards-visualizations.git",
     "index-management": "git@github.com:opensearch-project/index-management.git",
     "job-scheduler": "git@github.com:opensearch-project/job-scheduler.git",
     "k-nn": "git@github.com:opensearch-project/k-nn.git",


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Coming from: https://github.com/opensearch-project/dashboards-visualizations/issues/39#issuecomment-970555693 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
