### PR TITLE
Rename trace-analytics to observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@
 /security/
 /sql/
 /trace-analytics/
+/observability/
 /node_modules/
 /cross-cluster-replication/

--- a/.meta
+++ b/.meta
@@ -17,7 +17,7 @@
     "security-dashboards-plugin": "git@github.com:opensearch-project/security-dashboards-plugin",
     "security": "git@github.com:opensearch-project/security.git",
     "sql": "git@github.com:opensearch-project/sql.git",
-    "trace-analytics": "git@github.com:opensearch-project/trace-analytics.git",
+    "observability": "git@github.com:opensearch-project/observability.git",
     "cross-cluster-replication": "git@github.com:opensearch-project/cross-cluster-replication.git"
   }
 }

--- a/dashboards-plugins/.meta
+++ b/dashboards-plugins/.meta
@@ -7,7 +7,7 @@
     "indexManagementDashboards": "git@github.com:opensearch-project/index-management-dashboards-plugin.git",
     "anomalyDetectionDashboards": "git@github.com:opensearch-project/anomaly-detection-dashboards-plugin.git",
     "reportsDashboards": "git@github.com:opensearch-project/dashboards-reports.git",
-    "traceAnalyticsDashboards": "git@github.com:opensearch-project/trace-analytics.git",
+    "observabilityDashboards": "git@github.com:opensearch-project/observability.git",
     "ganttChartDashboards":"git@github.com:opensearch-project/dashboards-visualizations.git"
   }
 }

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -12,4 +12,5 @@
 /security-dashboards-plugin/
 /sql/
 /trace-analytics/
+/observability/
 /cross-cluster-replication/

--- a/plugins/.meta
+++ b/plugins/.meta
@@ -12,7 +12,7 @@
     "security-dashboards-plugin": "git@github.com:opensearch-project/security-dashboards-plugin.git",
     "security": "git@github.com:opensearch-project/security.git",
     "sql": "git@github.com:opensearch-project/sql.git",
-    "trace-analytics": "git@github.com:opensearch-project/trace-analytics.git",
+    "observability": "git@github.com:opensearch-project/observability.git",
     "cross-cluster-replication": "git@github.com:opensearch-project/cross-cluster-replication.git"
   }
 }


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Trace-analytics repo is renamed to Observability, rename it here as well
 
### Issues Resolved
https://github.com/opensearch-project/observability/issues/336
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
