### PR TITLE
Removed dashboards plugin.

### DIFF
--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -9,7 +9,6 @@
 /k-nn/
 /performance-analyzer/
 /security/
-/security-dashboards-plugin/
 /sql/
 /trace-analytics/
 /observability/

--- a/plugins/.meta
+++ b/plugins/.meta
@@ -9,7 +9,6 @@
     "job-scheduler": "git@github.com:opensearch-project/job-scheduler.git",
     "k-nn": "git@github.com:opensearch-project/k-nn.git",
     "performance-analyzer": "git@github.com:opensearch-project/performance-analyzer.git",
-    "security-dashboards-plugin": "git@github.com:opensearch-project/security-dashboards-plugin.git",
     "security": "git@github.com:opensearch-project/security.git",
     "sql": "git@github.com:opensearch-project/sql.git",
     "observability": "git@github.com:opensearch-project/observability.git",


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description
This is a dashboards plugin, misplaced.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
