### PR TITLE
Documenting usage of overriding Default Distribution Download URL with custom URL by setting external property customDistributionUrl

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -107,7 +107,7 @@ See [anomaly-detection#181](https://github.com/opensearch-project/anomaly-detect
 
 #### Distribution Download Plugin
 
-The Distribution Download plugin downloads the latest version of OpenSearch by default, and supports overriding this behavior by setting `customDistributionUrl`. This will help to pull artifacts fom custom location for testing during release process.
+The Distribution Download plugin downloads the latest version of OpenSearch by default, and supports overriding this behavior by setting `customDistributionUrl`. This will help to pull artifacts from custom location for testing during release process.
 ```
 ./gradlew integTest -DcustomDistributionUrl="https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz"
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,6 +13,8 @@
   - [Backwards Compatibility Testing](#backwards-compatibility-testing)
     - [Types of BWC tests](#types-of-bwc-tests)
     - [Hooking the BWC tests to CI](#hooking-the-bwc-tests-to-ci)
+  - [Gradle Plugins](#gradle-plugins)
+    - [Distribution Download plugin](#distribution-download-plugin)
 <!-- TOC -->
 
 ## Testing
@@ -100,3 +102,12 @@ Each plugin can test various functionalities in their bwc tests and add more sce
 The bwc tests can be hooked to the CI workflow in the plugin to run it with each pull request and push. 
 
 See [anomaly-detection#181](https://github.com/opensearch-project/anomaly-detection/pull/181) for more information.
+
+### Gradle Plugins
+
+#### Distribution Download Plugin
+
+The Distribution Download plugin downloads the latest version of OpenSearch by default, and supports overriding this behavior by setting `customDistributionUrl`. This will help to pull artifacts fom custom location for testing during release process.
+```
+./gradlew integTest -DcustomDistributionUrl="https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz"
+```

--- a/TESTING.md
+++ b/TESTING.md
@@ -109,5 +109,5 @@ See [anomaly-detection#181](https://github.com/opensearch-project/anomaly-detect
 
 The Distribution Download plugin downloads the latest version of OpenSearch by default, and supports overriding this behavior by setting `customDistributionUrl`. This will help to pull artifacts from custom location for testing during release process.
 ```
-./gradlew integTest -DcustomDistributionUrl="https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz"
+./gradlew integTest -PcustomDistributionUrl="https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz"
 ```


### PR DESCRIPTION
Signed-off-by: Rishikesh1159 <rishireddy1159@gmail.com>

### Description
This PR will allow developers to override Default Distribution Download URL with custom URL by setting "customDistributionUrl". This will help to pull artifacts from custom location for testing during release process.
 
### Issues Resolved
#126 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
