### PR TITLE
Adds dashboards-maps to opensearch-dashboards plugins

### DIFF
--- a/dashboards-plugins/.gitignore
+++ b/dashboards-plugins/.gitignore
@@ -7,3 +7,4 @@ queryWorkbenchDashboards/
 reportsDashboards/
 securityDashboards/
 traceAnalyticsDashboards/
+dashboards-maps/

--- a/dashboards-plugins/.meta
+++ b/dashboards-plugins/.meta
@@ -8,6 +8,7 @@
     "anomalyDetectionDashboards": "git@github.com:opensearch-project/anomaly-detection-dashboards-plugin.git",
     "reportsDashboards": "git@github.com:opensearch-project/dashboards-reports.git",
     "observabilityDashboards": "git@github.com:opensearch-project/observability.git",
-    "ganttChartDashboards":"git@github.com:opensearch-project/dashboards-visualizations.git"
+    "ganttChartDashboards": "git@github.com:opensearch-project/dashboards-visualizations.git",
+    "dashboards-maps": "git@github.com:opensearch-project/dashboards-maps.git"
   }
 }


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
Include [dashboards-maps](https://github.com/opensearch-project/dashboards-maps) plugin to meta.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2346

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
