### PR TITLE
Doc update: Plugin design version specifics

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -183,7 +183,7 @@ Use `./gradlew publishShadowPublicationToStagingRepository` to produce maven art
 * The maven coordinates `groupID`, `version` and `artifcatID` will be inferred from gradle project properties. (Prior to OpenSearch 2.4 the `groupId` was fixed as `org.openserach.plugin` regardless of actual gradle project `group` value or pluginZip publication POM customizations.)
 * User can also pass custom POM extensions, that will add desired properties to Apache Maven POM file generated during runtime.
 * Once the plugin is added to the `build.gradle` as `apply plugin: 'opensearch.pluginzip'`, this will add a new custom publish task `publishPluginZipPublicationToZipStagingRepository`, the purpose of this task is to publish the ZIP distribution to the Apache Maven local repository (file system).
-* Internally the plugin will apply both the '[nebula.maven-base-publish](https://plugins.gradle.org/plugin/nebula.maven-base-publish)' and '[maven-publish](https://docs.gradle.org/current/userguide/publishing_maven.html)' plugins which means that it is not necessary to explicitly apply these in your project. 
+* Since OpenSearch 2.4 this plugin internally applies both the '[nebula.maven-base-publish](https://plugins.gradle.org/plugin/nebula.maven-base-publish)' and '[maven-publish](https://docs.gradle.org/current/userguide/publishing_maven.html)' plugins which means that it is not necessary to explicitly apply these in your project. 
 * The Apache Maven local artifacts could then be published to Apache Maven central/nexus using [CI workflows](https://github.com/opensearch-project/opensearch-build/tree/main/jenkins).
 * The plugin will not publish generated JARs (`sourcesJar`, `javadocJar`), this is done on purpose to separate `jars` and `zip` publications.
 


### PR DESCRIPTION
### Description
This small PR makes it explicit about which plugin version apply internally other plugins. It is a follow-up of https://github.com/opensearch-project/opensearch-plugins/pull/175

I think users that need to build or maintain plugins for old OpenSearch versions (see https://github.com/opensearch-project/opensearch-plugin-template-java/issues/41) will find this information useful.

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>