### PR TITLE
Removing folder naming convention

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -8,9 +8,6 @@
   - [Artifacts](#artifacts)
     - [OpenSearch Plugins](#opensearch-plugins-2)
     - [OpenSearch Dashboards Plugins](#opensearch-dashboards-plugins)
-  - [Folders](#folders)
-    - [OpenSearch Plugins](#opensearch-plugins-3)
-    - [OpenSearch Dashboard Plugins](#opensearch-dashboard-plugins-2)
   - [Classes](#classes)
   - [Settings](#settings)
   - [APIs](#apis)
@@ -80,18 +77,6 @@ For example, [dashboards-notebooks/opensearch_dashboards.json](https://github.co
 #### OpenSearch Dashboards Plugins
 
 - Artifacts are of the `<package name>-<version>` format, e.g. `notebooks-dashboards-1.0.0.0-beta1.zip`.
-
-### Folders
-
-#### OpenSearch Plugins
-
-- Always use kebab-case.
-- Include full plugin name, e.g. `plugins/opensearch-knn`.
-
-#### OpenSearch Dashboard Plugins
-
-- Always use kebab-case.
-- Include full plugin name, e.g. `plugins/notebooks-dashboards`. The change to automatically convert folders to kebab-case is still pending, see [OpenSearch-Dashboards#322](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/322).
 
 ### Classes
 


### PR DESCRIPTION
This is because we're shifting to one plugin per repo as per  https://github.com/opensearch-project/opensearch-build/issues/2188

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Monica Kugler <monicank@amazon.com>