### PR TITLE
Update maps meta name to match plugin name

### DIFF
--- a/dashboards-plugins/.meta
+++ b/dashboards-plugins/.meta
@@ -9,6 +9,6 @@
     "reportsDashboards": "git@github.com:opensearch-project/dashboards-reports.git",
     "observabilityDashboards": "git@github.com:opensearch-project/observability.git",
     "ganttChartDashboards": "git@github.com:opensearch-project/dashboards-visualizations.git",
-    "dashboards-maps": "git@github.com:opensearch-project/dashboards-maps.git"
+    "customImportMapDashboards": "git@github.com:opensearch-project/dashboards-maps.git"
   }
 }


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description

Update maps meta name to match the plugin name

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/99


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
