### PR TITLE
Add/update several repos in dashboards-plugins/.meta

### DIFF
--- a/dashboards-plugins/.meta
+++ b/dashboards-plugins/.meta
@@ -1,14 +1,16 @@
 {
   "projects": {
-    "queryWorkbenchDashboards": "git@github.com:opensearch-project/sql.git",
+    "queryWorkbenchDashboards": "git@github.com:opensearch-project/dashboards-query-workbench.git",
     "alertingDashboards": "git@github.com:opensearch-project/alerting-dashboards-plugin.git",
-    "notificationsDashboards": "git@github.com:opensearch-project/notifications.git",
+    "notificationsDashboards": "git@github.com:opensearch-project/dashboards-notifications.git",
     "securityDashboards": "git@github.com:opensearch-project/security-dashboards-plugin",
     "indexManagementDashboards": "git@github.com:opensearch-project/index-management-dashboards-plugin.git",
     "anomalyDetectionDashboards": "git@github.com:opensearch-project/anomaly-detection-dashboards-plugin.git",
     "reportsDashboards": "git@github.com:opensearch-project/dashboards-reports.git",
-    "observabilityDashboards": "git@github.com:opensearch-project/observability.git",
+    "observabilityDashboards": "git@github.com:opensearch-project/dashboards-observability.git",
     "ganttChartDashboards": "git@github.com:opensearch-project/dashboards-visualizations.git",
-    "customImportMapDashboards": "git@github.com:opensearch-project/dashboards-maps.git"
+    "customImportMapDashboards": "git@github.com:opensearch-project/dashboards-maps.git",
+    "searchRelevanceDashboards": "git@github.com:opensearch-project/dashboards-search-relevance.git",
+    "opensearch-dashboards-functional-test": "git@github.com:opensearch-project/opensearch-dashboards-functional-test.git"
   }
 }


### PR DESCRIPTION
The following repos were missed by the release ticketing automation for the 2.6 OpenSearch release, because they were either missing from the .meta files (dashboards-search-relevance and opensearch-dashboards-functional-test) or they had out-of-date repo URIs (dashboards-notifications, dashboards-query-workbench, and dashboards-observability).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
