### PR TITLE
add convention for plugin location (relates to #13879)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,3 +1,4 @@
+- [Plugin Location](#plugin-location)
 - [Plugin Naming Conventions](#plugin-naming-conventions)
   - [GitHub](#github)
     - [OpenSearch Plugins](#opensearch-plugins)

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -19,7 +19,7 @@
 
 - Most plugins should start in a repository outside of the OpenSearch project. This allows for rapid iteration during initial development without the overhead of being an official part of the project.
 - Plugins can be later ported into the OpenSearch Project on a case-by-case basis. A formal path for this process is yet to be created.
-- Do not add new plugins to the [plugins folder](https://github.com/opensearch-project/OpenSearch/tree/main/plugins) within the project. This folder is within the core project, where the maintainers are not focussed on optional pluggable features. If you think it should be there anyway, please explain why in the RFC stage. In any case, it is recommended to start outside the project.   
+- Do not add new plugins to the [plugins folder](https://github.com/opensearch-project/OpenSearch/tree/main/plugins) within the core OpenSearch repository. The maintainers likely do not have domain expertise in your new optional plugin. If you think it should be there anyway, please explain why in the RFC stage. In any case, it is recommended to start outside the project.   
 
 ## Plugin Naming Conventions
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -17,7 +17,7 @@
 
 ## Plugin Location
 
-- Plugins should be created in their own external repository. External to the OpenSearch Project itself. 
+- Most plugins should start in a repository outside of the OpenSearch project. This allows for rapid iteration during initial development without the overhead of being an official part of the project.
 - Plugins can be later ported into the OpenSearch Project on a case-by-case basis. A formal path for this process is yet to be created.
 - Do not add new plugins to the [plugins folder](https://github.com/opensearch-project/OpenSearch/tree/main/plugins) within the project. This folder is within the core project, where the maintainers are not focussed on optional pluggable features. If you think it should be there anyway, please explain why in the RFC stage. In any case, it is recommended to start outside the project.   
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,4 +1,4 @@
-- [Plugin Location](#plugin-location)
+- [Creating New Plugins](#creating-new-plugins)
 - [Plugin Naming Conventions](#plugin-naming-conventions)
   - [GitHub](#github)
     - [OpenSearch Plugins](#opensearch-plugins)
@@ -16,11 +16,11 @@
   - [Identifiers](#identifiers)
   - [Variables](#variables)
 
-## Plugin Location
+## Creating New Plugins
 
-- Most plugins should start in a repository outside of the OpenSearch project. This allows for rapid iteration during initial development without the overhead of being an official part of the project.
-- Plugins can be later ported into the OpenSearch Project on a case-by-case basis. A formal path for this process is yet to be created.
-- Do not add new plugins to the [plugins folder](https://github.com/opensearch-project/OpenSearch/tree/main/plugins) within the core OpenSearch repository. The maintainers likely do not have domain expertise in your new optional plugin. If you think it should be there anyway, please explain why in the RFC stage. In any case, it is recommended to start outside the project.   
+- Create plugins in your own personal repo (outside of the opensearch-project). This allows for rapid iteration during initial development without the overhead of being an official part of the project.
+- Plugins can be later moved into the opensearch-project on a case-by-case basis. A formal path for this process is yet to be created.
+- Do not add new plugins to the [plugins folder](https://github.com/opensearch-project/OpenSearch/tree/main/plugins) within the core OpenSearch repository. The maintainers likely do not have domain expertise in your new optional plugin. If you think it should be there anyway, please explain why in the RFC stage.   
 
 ## Plugin Naming Conventions
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -15,6 +15,12 @@
   - [Identifiers](#identifiers)
   - [Variables](#variables)
 
+## Plugin Location
+
+- Plugins should be created in their own external repository. External to the OpenSearch Project itself. 
+- Plugins can be later ported into the OpenSearch Project on a case-by-case basis. A formal path for this process is yet to be created.
+- Do not add new plugins to the [plugins folder](https://github.com/opensearch-project/OpenSearch/tree/main/plugins) within the project. This folder is within the core project, where the maintainers are not focussed on optional pluggable features. If you think it should be there anyway, please explain why in the RFC stage. In any case, it is recommended to start outside the project.   
+
 ## Plugin Naming Conventions
 
 ### GitHub


### PR DESCRIPTION
### Description
adding convention for where plugin code should be

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/13879

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
