### PR TITLE
add flowFrameworkDashboards

### DIFF
--- a/dashboards-plugins/.gitignore
+++ b/dashboards-plugins/.gitignore
@@ -12,3 +12,4 @@ customImportMapDashboards/
 securityAnalyticsDashboards/
 mlCommonsDashboards/
 assistantDashboards/
+flowFrameworkDashboards/

--- a/dashboards-plugins/.meta
+++ b/dashboards-plugins/.meta
@@ -13,6 +13,7 @@
     "customImportMapDashboards": "git@github.com:opensearch-project/dashboards-maps.git",
     "securityAnalyticsDashboards": "git@github.com:opensearch-project/security-analytics-dashboards-plugin.git",
     "mlCommonsDashboards": "git@github.com:opensearch-project/ml-commons-dashboards.git",
-    "assistantDashboards": "git@github.com:opensearch-project/dashboards-assistant.git"
+    "assistantDashboards": "git@github.com:opensearch-project/dashboards-assistant.git",
+    "flowFrameworkDashboards": "git@github.com:opensearch-project/dashboards-flow-framework.git"
   }
 }


### PR DESCRIPTION
### Description
add https://github.com/opensearch-project/dashboards-flow-framework

### Issues Resolved
Related to https://github.com/opensearch-project/opensearch-build/issues/4851

#### dashboards-flow-framework plugin is expected to release with OpenSearch 2.17.  
#### Plugin is not yet stable. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
