### PR TITLE
Add query insights dashboards to dashboards meta

### DIFF
--- a/dashboards-plugins/.meta
+++ b/dashboards-plugins/.meta
@@ -14,6 +14,7 @@
     "securityAnalyticsDashboards": "git@github.com:opensearch-project/security-analytics-dashboards-plugin.git",
     "mlCommonsDashboards": "git@github.com:opensearch-project/ml-commons-dashboards.git",
     "assistantDashboards": "git@github.com:opensearch-project/dashboards-assistant.git",
-    "flowFrameworkDashboards": "git@github.com:opensearch-project/dashboards-flow-framework.git"
+    "flowFrameworkDashboards": "git@github.com:opensearch-project/dashboards-flow-framework.git",
+    "queryInsightsDashboards": "git@github.com:opensearch-project/query-insights-dashboards.git"
   }
 }


### PR DESCRIPTION
### Description
Add query insights dashboards to dashboards meta

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5152

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
