### PR TITLE
Updated affiliation for @dblock.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer         | GitHub ID                                               | Affiliation |
 | ------------------ | ------------------------------------------------------- | ----------- |
-| Daniel Doubrovkine | [dblock](https://github.com/dblock)                     | Amazon      |
+| Daniel Doubrovkine | [dblock](https://github.com/dblock)                     | Independent |
 | Sarat Vemulapalli  | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
 | Tianli Feng        | [tlfeng](https://github.com/tlfeng)                     | Amazon      |
 | Tyler Ohlsen       | [ohltyler](https://github.com/ohltyler)                 | Amazon      |


### PR DESCRIPTION
### Description

Updated affiliation for @dblock.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
