### PR TITLE
fix(docs): Update System.env syntax for Gradle 9 compatibility

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -99,8 +99,8 @@ In order to onboard, follow the below steps:
             name = "Snapshots"
             url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
             credentials {
-                username "$System.env.SONATYPE_USERNAME"
-                password "$System.env.SONATYPE_PASSWORD"
+                username System.getenv("SONATYPE_USERNAME")
+                password System.getenv("SONATYPE_PASSWORD")
             }
         }
     }


### PR DESCRIPTION
This PR updates the documentation for plugin Gradle build files to fix compatibility with Gradle 9.

## Problem
The current syntax using `$System.env.VARIABLE_NAME` for accessing environment variables is not compatible with Gradle 9.

This format is used for Sonatype credentials for SNAPSHOT publication. This fails with under Gradle 9.
```gradle
credentials {
    username = "$System.env.SONATYPE_USERNAME"
    password = "$System.env.SONATYPE_PASSWORD"
}
```

See [example failed workflow here](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/actions/runs/17023398832/job/48255946880#step:5:74).

## Solution
Update to use the `System.getenv()` method instead:
```gradle
credentials {
    username = System.getenv("SONATYPE_USERNAME")
    password = System.getenv("SONATYPE_PASSWORD")
}
```

Example fix which restored successful snapshots: https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/245

PRs submitted org-wide to update:
 - https://github.com/opensearch-project/user-behavior-insights/pull/122
 - https://github.com/opensearch-project/sql/pull/4090
 - https://github.com/opensearch-project/skills/pull/630
 - https://github.com/opensearch-project/security-analytics/pull/1571
 - https://github.com/opensearch-project/security/pull/5577
 - https://github.com/opensearch-project/search-relevance/pull/227
 - https://github.com/opensearch-project/reporting/pull/1120
 - https://github.com/opensearch-project/query-insights/pull/407
 - https://github.com/opensearch-project/opensearch-system-templates/pull/95
 - https://github.com/opensearch-project/performance-analyzer/pull/841
 - https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/219
 - https://github.com/opensearch-project/opensearch-sdk-java/pull/1031
 - https://github.com/opensearch-project/opensearch-jvector/pull/140
 - https://github.com/opensearch-project/OpenSearch/pull/19119
 - https://github.com/opensearch-project/observability/pull/1943
 - https://github.com/opensearch-project/notifications/pull/1069
 - https://github.com/opensearch-project/neural-search/pull/1521
 - https://github.com/opensearch-project/ml-commons/pull/4129
 - https://github.com/opensearch-project/k-NN/pull/2855
 - https://github.com/opensearch-project/job-scheduler/pull/821
 - https://github.com/opensearch-project/index-management/pull/1474
 - https://github.com/opensearch-project/geospatial/pull/791
 - https://github.com/opensearch-project/data-prepper/pull/6004
 - https://github.com/opensearch-project/custom-codecs/pull/273
 - https://github.com/opensearch-project/cross-cluster-replication/pull/1575
 - https://github.com/opensearch-project/common-utils/pull/867
 - https://github.com/opensearch-project/asynchronous-search/pull/763
 - https://github.com/opensearch-project/anomaly-detection/pull/1554
 - https://github.com/opensearch-project/alerting/pull/1920
 - https://github.com/opensearch-project/flow-framework/pull/1219


